### PR TITLE
Add support for gzip compression (+ configurable timeouts)

### DIFF
--- a/lib/exquickbooks/api/batch.ex
+++ b/lib/exquickbooks/api/batch.ex
@@ -14,11 +14,11 @@ defmodule ExQuickBooks.API.Batch do
   @doc """
   Performs the given query operations in a single request
   """
-  @spec read_batch(Credentials.t(), list(%{bId: String.t(), Query: String.t()})) ::
+  @spec read_batch(Credentials.t(), list(%{bId: String.t(), Query: String.t()}), keyword()) ::
           {:ok, json_map} | {:error, any}
-  def read_batch(credentials, queries) do
+  def read_batch(credentials, queries, opts \\ []) do
     credentials
-    |> make_request(:post, "batch", Jason.encode!(%{BatchItemRequest: queries}))
+    |> make_request(:post, "batch", Jason.encode!(%{BatchItemRequest: queries}), nil, opts)
     |> sign_request(credentials)
     |> send_json_request()
   end

--- a/lib/exquickbooks/api/reports.ex
+++ b/lib/exquickbooks/api/reports.ex
@@ -14,13 +14,13 @@ defmodule ExQuickBooks.API.Reports do
   @doc """
   Retrieves the given report.
   """
-  @spec read_report(Credentials.t(), String.t(), %{String.t() => String.t()}) ::
+  @spec read_report(Credentials.t(), String.t(), %{String.t() => String.t()}, keyword()) ::
           {:ok, json_map} | {:error, any}
-  def read_report(credentials, report_type, options \\ %{}) do
-    query = URI.encode_query(options)
+  def read_report(credentials, report_type, params \\ %{}, opts \\ []) do
+    query = URI.encode_query(params)
 
     credentials
-    |> make_request(:get, "reports/#{report_type}?#{query}")
+    |> make_request(:get, "reports/#{report_type}?#{query}", nil, nil, opts)
     |> sign_request(credentials)
     |> send_json_request()
   end


### PR DESCRIPTION
For really large reports, these payloads can quickly get huge. Enabling gzip compression is a quick win for dramatically reducing the volume of data sent over the wire.